### PR TITLE
docs: initial pass at documenting API and Webhook routes 

### DIFF
--- a/src/clj/owlet/routes/home.clj
+++ b/src/clj/owlet/routes/home.clj
@@ -10,7 +10,6 @@
 (defroutes home-routes
   (GET "/" []
        (index-page))
-  (GET "/docs" []
+  (GET "/docs/ui" []
        (-> (response/ok (-> "docs/docs.md" io/resource slurp))
            (response/header "Content-Type" "text/plain; charset=utf-8"))))
-

--- a/src/clj/owlet/routes/services.clj
+++ b/src/clj/owlet/routes/services.clj
@@ -25,4 +25,31 @@
 				param to get all entries for given space"
         (ok {:metadata   {},
              :activities [],
-             :platforms  []})))))
+             :platforms  []})))
+
+    (context "/webhook" []
+
+      :tags ["Webhooks"]
+
+      ;; TODO: (david) document returns
+
+      (context "/content" []
+
+        (GET "/confirm" []
+         :query-params [id]
+         :summary "Confirmation route, gets hit by the front end")
+
+        (POST "/email" []
+          :query-params [payload]
+          :summary "Sends email to list of subscribers")
+
+        (PUT "/subscribe" []
+          :query-params [email]
+          :summary
+          "handles new subscription request -checks list of subs b4 adding to list; ie no duplicates")
+
+        (PUT "/unsubscribe" []
+          :query-params [email]
+          :summary
+          "handles new subscription request -checks list of subs b4 adding to list; ie no duplicates")))))
+

--- a/src/clj/owlet/routes/services.clj
+++ b/src/clj/owlet/routes/services.clj
@@ -1,44 +1,29 @@
 (ns owlet.routes.services
   (:require [ring.util.http-response :refer :all]
             [compojure.api.sweet :refer :all]
+            [cheshire.core :as json]
             [schema.core :as s]))
 
 (defapi service-routes
-  {:swagger {:ui "/swagger-ui"
+
+  {:swagger {:ui   "/api/docs"
              :spec "/swagger.json"
-             :data {:info {:version "1.0.0"
-                           :title "Sample API"
-                           :description "Sample Services"}}}}
-  
+             :data {:info {:version     "0.0.1"
+                           :title       "Owlet API"
+                           :description "Services & Webhooks"}}}}
+
   (context "/api" []
-    :tags ["thingie"]
 
-    (GET "/plus" []
-      :return       Long
-      :query-params [x :- Long, {y :- Long 1}]
-      :summary      "x+y with query-parameters. y defaults to 1."
-      (ok (+ x y)))
+    :tags ["API"]
 
-    (POST "/minus" []
-      :return      Long
-      :body-params [x :- Long, y :- Long]
-      :summary     "x-y with body-parameters."
-      (ok (- x y)))
+    (context "/content" []
 
-    (GET "/times/:x/:y" []
-      :return      Long
-      :path-params [x :- Long, y :- Long]
-      :summary     "x*y with path-parameters"
-      (ok (* x y)))
-
-    (POST "/divide" []
-      :return      Double
-      :form-params [x :- Long, y :- Long]
-      :summary     "x/y with form-parameters"
-      (ok (/ x y)))
-
-    (GET "/power" []
-      :return      Long
-      :header-params [x :- Long, y :- Long]
-      :summary     "x^y with header-parameters"
-      (ok (long (Math/pow x y))))))
+      (GET "/space" []
+        :query-params [space-id, library-view :- Boolean]
+        :summary
+        "Asynchronously GETs all entries for given,
+				optionally pass library-view=true
+				param to get all entries for given space"
+        (ok {:metadata   {},
+             :activities [],
+             :platforms  []})))))

--- a/src/clj/owlet/routes/services.clj
+++ b/src/clj/owlet/routes/services.clj
@@ -1,7 +1,6 @@
 (ns owlet.routes.services
   (:require [ring.util.http-response :refer :all]
             [compojure.api.sweet :refer :all]
-            [cheshire.core :as json]
             [schema.core :as s]))
 
 (defapi service-routes

--- a/src/clj/owlet/routes/services.clj
+++ b/src/clj/owlet/routes/services.clj
@@ -5,7 +5,7 @@
 
 (defapi service-routes
 
-  {:swagger {:ui   "/api/docs"
+  {:swagger {:ui   "/docs/api"
              :spec "/swagger.json"
              :data {:info {:version     "0.0.1"
                            :title       "Owlet API"
@@ -52,4 +52,3 @@
           :query-params [email]
           :summary
           "handles new subscription request -checks list of subs b4 adding to list; ie no duplicates")))))
-


### PR DESCRIPTION
Adds swagger API Docs

Accessable via `owlet.codefordenver.org/api/docs` once deployed. 
Locally `http://localhost:3000/api/docs`
<img width="982" alt="screen shot 2017-09-14 at 9 38 40 pm" src="https://user-images.githubusercontent.com/144226/30465595-209f22b0-9995-11e7-9944-4a317db0315c.png">

Note: return values are missing. Will be addressed by: https://github.com/codefordenver/owlet/issues/284
