### PR TITLE
refactor: decomplect github stats request

### DIFF
--- a/src/clj/owlet/routes/github.clj
+++ b/src/clj/owlet/routes/github.clj
@@ -11,7 +11,7 @@
 
 (def OWLET_GITHUB_TOKEN (System/getenv "OWLET_GITHUB_TOKEN"))
 
-(defn get-labels [weeks]
+(defn get-week-labels [weeks]
   (map #(f/unparse (f/formatter "MMM YYYY") (c/from-long (* % 1000))) weeks))
 
 (defn proxy-github-request
@@ -22,7 +22,7 @@
     (when (= status 200)
       (let [stats (json/parse-string body true)
             weeks (map :week stats)
-            labels (get-labels weeks)
+            labels (get-week-labels weeks)
             totals (map :total stats)
             deduped (dedupe labels)]
         (ok {:status status

--- a/src/clj/owlet/routes/github.clj
+++ b/src/clj/owlet/routes/github.clj
@@ -11,19 +11,8 @@
 
 (def OWLET_GITHUB_TOKEN (System/getenv "OWLET_GITHUB_TOKEN"))
 
-(defn in? [coll x]
-   (some #(= x %) coll))
-
-(defn get-labels [stats]
-  (mapv (fn [l]
-         (let [label (f/unparse (f/formatter "MMM YYYY") (c/from-long (* (get l :week) 1000)))]
-           (if-not (in? @stored-labels label)
-             (do
-               (reset! stored-labels (conj @stored-labels label))
-               label)
-             ""))) (map #(select-keys % [:week]) stats)))
-
-(def stored-labels (atom []))
+(defn get-labels [weeks]
+  (map #(f/unparse (f/formatter "MMM YYYY") (c/from-long (* % 1000))) weeks))
 
 (defn proxy-github-request
   "proxy front end request"
@@ -31,16 +20,15 @@
   (let [headers {:Authorization OWLET_GITHUB_TOKEN}
         {:keys [status body]} @(http/get "https://api.github.com/repos/codefordenver/owlet/stats/commit_activity" headers)]
     (when (= status 200)
-      (reset! stored-labels [])
       (let [stats (json/parse-string body true)
-            labels (get-labels stats)
-            totals (map #(get % :total) stats)]
-        (reset! stored-labels (mapv #(f/unparse (f/formatter "MMM YYYY") (c/from-long (* (get % :week) 1000))) (map #(select-keys % [:week]) stats)))
-        (reset! stored-labels (take-nth 2 (drop 1 (dedupe @stored-labels))))
-        (let [reduced-labels (get-labels stats)]
-          (ok {:status status
-               :body {:labels labels, :reduced-labels reduced-labels, :totals totals}}))))))
-
+            weeks (map :week stats)
+            labels (get-labels weeks)
+            totals (map :total stats)
+            deduped (dedupe labels)]
+        (ok {:status status
+             :body   {:labels         (interleave (take (count labels) (repeat "")) deduped)
+                      :reduced-labels deduped
+                      :totals         totals}})))))
 
 (defroutes routes
            (GET "/stats" {params :params} proxy-github-request))

--- a/src/cljs/owlet/views/about.cljs
+++ b/src/cljs/owlet/views/about.cljs
@@ -27,11 +27,10 @@
                                         :legend {:onClick nil}
                                         :scales {:xAxes [{:ticks {:autoSkip false}}]}}})))))
 
-(defn handle-stats [response]
-  (let [res (js->clj (clj->js response) :keywordize-keys true)
-        all (get-in res [:body :labels])
-        reduced (get-in res [:body :reduced-labels])
-        data (get-in res [:body :totals])]
+(defn handle-stats [res]
+  (let [all (-> res :body :labels)
+        reduced (-> res :body :reduced-labels)
+        data (-> res :body :totals)]
     (set! (.-onresize js/window) (fn []
                                    (let [w (.-innerWidth js/window)]
                                      (reset! hide-labels? (<= w 800))
@@ -50,10 +49,13 @@
 
 (defn about-view []
   (reagent/create-class
+
     {:component-did-mount
-      (fn []
-        (GET stats-endpoint {:handler handle-stats
-                             :format :json}))
+      #(GET stats-endpoint
+            {:handler handle-stats
+             :keywords? true
+             :response-format :json})
+
      :reagent-render
      (fn []
        [:div.information-wrap


### PR DESCRIPTION
Mostly the same except without the need to store labels in an atom. 
@ZadenRB let's go through this tomorrow at hacknight.