### PR TITLE
FIX for broken Auth0 login

### DIFF
--- a/src/cljs/owlet/components/login.cljs
+++ b/src/cljs/owlet/components/login.cljs
@@ -7,14 +7,14 @@
   []
   [:button.btn-signup
    {:type     "button"
-    :on-click #(.show (auth0/lock "signup"))}
+    :on-click #(auth0/show-lock :initialScreen :signUp)}
    "Sign Up"])
 
 (defn login-button
   []
   [:button.btn-login
    {:type     "button"
-    :on-click #(.show (auth0/lock "login"))}
+    :on-click #(auth0/show-lock :initialScreen :login)}
    "Log in"])
 
 

--- a/src/cljs/owlet/main.cljs
+++ b/src/cljs/owlet/main.cljs
@@ -47,7 +47,7 @@
   [views view-name])
 
 (defn view []
-  (auth0/on-authenticated (auth0/lock "login")
+  (auth0/on-authenticated auth0/lock
                           config/auth0-del-opts-for-firebase
                           :auth0-authenticated
                           :auth0-error)

--- a/src/cljs/owlet/views/login_only.cljs
+++ b/src/cljs/owlet/views/login_only.cljs
@@ -8,6 +8,6 @@
     [:div.information-inner
      [:div.inner-height-wrap
       [:h1 [:mark {:style {:cursor "pointer"}
-                   :on-click #(.show (auth0/lock "login"))}
+                   :on-click #(auth0/show-lock :initialScreen :login)}
             "Log in"]]
       [:h2 "You must be logged in to view this page."]]]]])


### PR DESCRIPTION
owlet.auth0/lock singleton reborn with a new function, owlet.auth0/show-lock, which brings up any of the three kinds of login modal dialogs, given the appropriate option.