### PR TITLE
Extends the simplemde function to handle user actions like "click" or "blur".

### DIFF
--- a/src/cljs/owlet/components/creation/create_klipse_panel.cljs
+++ b/src/cljs/owlet/components/creation/create_klipse_panel.cljs
@@ -3,14 +3,17 @@
             [owlet.components.creation.custom-klipse-component :refer [custom-klipse-component]]
             [owlet.components.creation.create-klipse-code-validation :refer [create-klipse-code-validation-component]]
             [re-com.core :refer [h-box button]]
-            [owlet.components.creation.markdown-editor :refer [simplemde]]))
+            [owlet.components.creation.markdown-editor :refer [simplemde]]
+            [owlet.events.create-activity :as create]))
+
 
 (defn create-klipse-panel-component [id]
   (reagent/create-class
     {:component-did-mount
      (fn []
-       (let [smde-text1 (simplemde "text1")
-             smde-text2 (simplemde "text2")]))
+       (simplemde :text1 :blur ::create/text)
+       (simplemde :text2 :blur ::create/text))
+
      :reagent-render
      (fn [id]
       [:div.activity-creation-wrap

--- a/src/cljs/owlet/components/creation/general_activity_text_fields.cljs
+++ b/src/cljs/owlet/components/creation/general_activity_text_fields.cljs
@@ -1,14 +1,17 @@
 (ns owlet.components.creation.general-activity-text-fields
   (:require [reagent.core :as reagent]
-            [owlet.components.creation.markdown-editor :refer [simplemde]]))
+            [owlet.components.creation.markdown-editor :refer [simplemde]]
+            [owlet.events.create-activity :as create]))
+
 
 (defn general-activity-text-fields []
   (reagent/create-class
     {:component-did-mount
      (fn []
-       (let [smde-why (simplemde "why")
-             smde-materials (simplemde "materials")
-             smde-prereqs (simplemde "prereqs")]))
+       (simplemde :why :blur ::create/text)
+       (simplemde :prereqs :blur ::create/text)
+       (simplemde :materials :blur ::create/text))
+
      :reagent-render
      (fn []
        [:div#general-activity-info

--- a/src/cljs/owlet/components/creation/markdown_editor.cljs
+++ b/src/cljs/owlet/components/creation/markdown_editor.cljs
@@ -3,7 +3,7 @@
             [re-frame.core :as rf]))
 
 
-(defn simplemde [textarea-id codemirror-evt-type rf-evt-id & more-evt-args]
+(defn simplemde
   "Creates and returns a new Markdown editor, attaching it to the DOM element
   indicated by textarea-id. It makes use of an instance of CodeMirror to do the
   editing. When an event of the given type is fired by the instance, it will be
@@ -15,6 +15,7 @@
   keywords, strings, or symbols. The remaining arguments will be literally
   passed to the event vector.
   "
+  [textarea-id codemirror-evt-type rf-evt-id & more-evt-args]
   (let [area-id (name textarea-id)
 
         mde (js/SimpleMDE. (clj->js

--- a/src/cljs/owlet/components/creation/markdown_editor.cljs
+++ b/src/cljs/owlet/components/creation/markdown_editor.cljs
@@ -1,9 +1,37 @@
 (ns owlet.components.creation.markdown-editor
-  (:require cljsjs.simplemde))
+  (:require cljsjs.simplemde
+            [re-frame.core :as rf]))
 
-(defn simplemde [id]
-  (js/SimpleMDE. #js {:element (js/document.querySelector (str "#" id))
-                      :forceSync true
-                      :lineWrapping true
-                      :autosave #js {:enabled true
-                                     :uniqueId id}}))
+
+(defn simplemde [textarea-id codemirror-evt-type rf-evt-id & more-evt-args]
+  "Creates and returns a new Markdown editor, attaching it to the DOM element
+  indicated by textarea-id. It makes use of an instance of CodeMirror to do the
+  editing. When an event of the given type is fired by the instance, it will be
+  handled by firing a re-frame event with the given rf-evt-id. The remaining
+  members of the event vector will then be the current text in the editor, the
+  textarea-id, and any more event arguments you provide. For standard values of
+  codemirror-evt-type, see https://codemirror.net/doc/manual.html#events
+  The textarea-id and codemirror-evt-type arguments may be provided as
+  keywords, strings, or symbols. The remaining arguments will be literally
+  passed to the event vector.
+  "
+  (let [area-id (name textarea-id)
+
+        mde (js/SimpleMDE. (clj->js
+                             {:element (js/document.getElementById area-id)
+                              :forceSync true
+                              :lineWrapping true
+                              :autosave {:enabled true :uniqueId area-id}}))
+
+        listener (fn [_js-evt]
+                   (let [users-text (.value mde)
+                         rf-event (into [rf-evt-id users-text textarea-id]
+                                        more-evt-args)]
+                     (rf/dispatch rf-event)))]
+
+    (-> mde
+      .-codemirror
+      (.on (name codemirror-evt-type) listener))
+
+    mde))
+

--- a/src/cljs/owlet/events/create_activity.cljs
+++ b/src/cljs/owlet/events/create_activity.cljs
@@ -1,0 +1,14 @@
+(ns owlet.events.create-activity
+  (:require [re-frame.core :as rf]))
+
+
+(defn text
+  [db [_ textarea-value field-id :as event]]
+  ; For now, we just show the event. We probably want to issue effect
+  ; :firebase-reset-ref or similar at this point.
+  (js/console.log "text handler event:\n\t" (str event))
+  db)
+; Used here:
+(rf/reg-event-db
+  ::text
+  text)


### PR DESCRIPTION
Such events are converted to re-frame event vectors and handled by a new re-frame event handler, :owlet.events.create-activity/text. For now, the handler just logs the re-frame event vector, but going forward, we can easily have it save the user's MarkDown text to Firebase.